### PR TITLE
T04 Lab - The step for the generation of sasToken is missing

### DIFF
--- a/Instructions/Labs/AZ-203_04_lab.md
+++ b/Instructions/Labs/AZ-203_04_lab.md
@@ -392,22 +392,28 @@ In this exercise, you securely used a service identity to read the value of a se
         SharedAccessExpiryTime = DateTime.UtcNow.AddHours(2),
         Protocols = SharedAccessProtocol.HttpsOnly
     };
+    
+3.  Add the following line of code to use the CloudStorageAccount.GetSharedAcessSignature method to generate a new Shared Access Signature (SAS) token by using the provided policy, and then store the result in a string variable named sasToken:
 
-3.  Concatenate the value of the **CloudBlockBlob.Uri** property and the *sasToken* string variable, and store the result in a new variable named *secureBlobUrl*:
+<!-- end list -->
+
+    string sasToken = account.GetSharedAccessSignature(policy);
+
+4.  Concatenate the value of the **CloudBlockBlob.Uri** property and the *sasToken* string variable, and store the result in a new variable named *secureBlobUrl*:
 
 <!-- end list -->
 
     string secureBlobUrl = $"{blob.Uri}{sasToken}";
 
-4.  Return the value of the *secureBlobUrl* variable by using the **OkObjectResult** class constructor:
+5.  Return the value of the *secureBlobUrl* variable by using the **OkObjectResult** class constructor:
 
 <!-- end list -->
 
     return new OkObjectResult(secureBlobUrl);
 
-5.  Use the **Save and run** button to perform a test execution of the function. The output from the execution should be a unique **Secure Url** that can be used to access the secured blob. Record this **Url** because you will need to use it in the next step of this lab.
+6.  Use the **Save and run** button to perform a test execution of the function. The output from the execution should be a unique **Secure Url** that can be used to access the secured blob. Record this **Url** because you will need to use it in the next step of this lab.
 
-6.  Using a new browser window or tab, navigate to the **Secure Url** for the blob and view the blob’s contents.
+7.  Using a new browser window or tab, navigate to the **Secure Url** for the blob and view the blob’s contents.
 
 #### Review
 


### PR DESCRIPTION
# Module: 4 - Implement Azure security
## Lab: Exercise 4 - Access Storage Account blobs
### Task: 5 - Generate a Shared Access Signature (SAS)
#### Step: Concatenate the value of the CloudBlockBlob.Uri property and the sasToken string variable, and store the result in a new variable named secureBlobUrl:

Description of issue:
The step for sasToken generation was missing in the lab (but was present in the lab response).

Fixes #13 

Changes proposed in this pull request:

- The step for sasToken generation was added in the lab instructions.
-
-