### PR TITLE
Fixed #22 Lab 1, Ex 3, Step 4 - Command not work

### DIFF
--- a/Instructions/Labs/AZ-203_01_lab.md
+++ b/Instructions/Labs/AZ-203_01_lab.md
@@ -301,7 +301,7 @@ In this exercise, you used the Azure Cloud Shell to create a virtual machine as 
 1.  Use the following command to save the name of the most recently created **container registry** in a Bash shell variable *acrName*:
 
     ```
-    acrName=`(az acr list --query "max_by([], &creationDate).name" --output tsv)`
+    acrName=$(az acr list --query "max_by([], &creationDate).name" --output tsv)
     ```
 
 1.  Use the following script to print the value of the Bash shell variable *acrName*:

--- a/Instructions/Labs/AZ-203_01_lab.md
+++ b/Instructions/Labs/AZ-203_01_lab.md
@@ -301,7 +301,7 @@ In this exercise, you used the Azure Cloud Shell to create a virtual machine as 
 1.  Use the following command to save the name of the most recently created **container registry** in a Bash shell variable *acrName*:
 
     ```
-    $acrName=(az acr list --query "max_by([], &creationDate).name" --output tsv)
+    acrName=`(az acr list --query "max_by([], &creationDate).name" --output tsv)`
     ```
 
 1.  Use the following script to print the value of the Bash shell variable *acrName*:


### PR DESCRIPTION
Module: AZ-203
Lab/Demo: 01
Task: 3
Step: 4

4.  Use the following command to save the name of the most recently created **container registry** in a Bash shell variable *acrName*:

    ```
    $acrName=(az acr list --query "max_by([], &creationDate).name" --output tsv)
    ```

It's not working within Azire Cloud Shell

```
// I gonna try
junhyun@Azure:~/clouddrive$ az acr list --query "max_by([], &creationDate).name" --output tsv
>>az203bjh201906
junhyun@Azure:~/clouddrive$ $acrName=(az acr list --query "max_by([], &creationDate).name" --output tsv)
>> bash: syntax error near unexpected token `az'
// It's not working

junhyun@Azure:~/clouddrive$ acrName=`(az acr list --query "max_by([], &creationDate).name" --output tsv)`
junhyun@Azure:~/clouddrive$ echo $acrName
>>az203bjh201906
// Done
```

Fixed #22 Lab 1, Ex 3, Step 4 - Command not work