### PR TITLE
Updating "using blocks" phrase

### DIFF
--- a/Instructions/Labs/AZ-203_02_lab.md
+++ b/Instructions/Labs/AZ-203_02_lab.md
@@ -485,7 +485,7 @@ In this exercise, you created an Azure Web App and deployed an existing web appl
     log.LogInformation($"C# Blob trigger function Processed blob\n Name:{name} \n Size: {inputBlob.Length} Bytes");
     ```
 
-1. Add the following **using** block to load the **Stream** for the input blob into the image library:
+1. Add the following **using** statement to load the **Stream** for the input blob into the image library:
 
     ```
     using (Image<Rgba32> image = Image.Load(inputBlob))
@@ -493,7 +493,7 @@ In this exercise, you created an Azure Web App and deployed an existing web appl
     }
     ```
 
-1. Add the following lines of code within the **using** block to mutate the image by resizing the image and applying a grayscale filter:
+1. Add the following lines of code within the **using** statement to mutate the image by resizing the image and applying a grayscale filter:
 
     ```
     image.Mutate(i => 	

--- a/Instructions/Labs/AZ-203_02_lab_ak.md
+++ b/Instructions/Labs/AZ-203_02_lab_ak.md
@@ -698,7 +698,7 @@ In this exercise, you created an Azure Web App and deployed an existing web appl
     log.LogInformation($"C# Blob trigger function Processed blob\n Name:{name} \n Size: {inputBlob.Length} Bytes");
     ```
 
-1. Add the following **using** block to load the **Stream** for the input blob into the image library:
+1. Add the following **using** statement to load the **Stream** for the input blob into the image library:
 
     ```
     using (Image<Rgba32> image = Image.Load(inputBlob))
@@ -706,7 +706,7 @@ In this exercise, you created an Azure Web App and deployed an existing web appl
     }
     ```
 
-1. Add the following lines of code within the **using** block to mutate the image by resizing the image and applying a grayscale filter:
+1. Add the following lines of code within the **using** statement to mutate the image by resizing the image and applying a grayscale filter:
 
     ```
     image.Mutate(i => 	

--- a/Instructions/Labs/AZ-203_03_lab.md
+++ b/Instructions/Labs/AZ-203_03_lab.md
@@ -421,7 +421,7 @@ In this exercise, you configured your ASP.NET Core web application to connect to
 
 1.  Delete all existing code in the **Program.cs** file.
 
-1.  Add the following using blocks for libraries that will be referenced by the application:
+1.  Add the following **using** directives for libraries that will be referenced by the application:
 
     ```
     using AdventureWorks.Context;
@@ -598,7 +598,7 @@ In this exercise, you used Entity Framework and the .NET SDK for Azure Cosmos DB
 
 1.  Create a new **AdventureWorks.Context/AdventureWorksCosmosContext.cs** file in Visual Studio Code.
 
-1.  Add the following using blocks for libraries that will be referenced by the application:
+1.  Add the following **using** directives for libraries that will be referenced by the application:
 
     ```
     using AdventureWorks.Models;
@@ -835,7 +835,7 @@ In this exercise, you wrote C# code to query an Azure Cosmos DB collection using
 
 1.  Create a new **AdventureWorks.Context/AdventureWorksRedisContext.cs** file in Visual Studio Code.
 
-1.  Add the following using blocks for libraries that will be referenced by the application:
+1.  Add the following **using** directives for libraries that will be referenced by the application:
 
     ```
     using AdventureWorks.Models;

--- a/Instructions/Labs/AZ-203_03_lab_ak.md
+++ b/Instructions/Labs/AZ-203_03_lab_ak.md
@@ -631,7 +631,7 @@ In this exercise, you configured your ASP.NET Core web application to connect to
     using Microsoft.EntityFrameworkCore;
     ```
 
-1.  Add the following lines of code to add using blocks for built-in namespaces that will be used in this file:
+1.  Add the following lines of code to add **using** directives for built-in namespaces that will be used in this file:
 
     ```
     using System;
@@ -922,7 +922,7 @@ In this exercise, you used Entity Framework and the .NET SDK for Azure Cosmos DB
     using Microsoft.Azure.Cosmos.Linq;
     ```
 
-1.  Add the following lines of code to add using blocks for built-in namespaces that will be used in this file:
+1.  Add the following lines of code to add **using** directives for built-in namespaces that will be used in this file:
 
     ```
     using System;
@@ -1244,7 +1244,7 @@ In this exercise, you wrote C# code to query an Azure Cosmos DB collection using
     using StackExchange.Redis;
     ```
 
-1.  Add the following lines of code to add using blocks for built-in namespaces that will be used in this file:
+1.  Add the following lines of code to add **using** directives for built-in namespaces that will be used in this file:
 
     ```
     using System;

--- a/Instructions/Labs/AZ-203_04_lab.md
+++ b/Instructions/Labs/AZ-203_04_lab.md
@@ -338,7 +338,7 @@ In this exercise, you securely used a service identity to read the value of a se
 
 1.  Return to the editor for the **FileParser** function by clicking the **run.csx** file in the **View files** tab.
 
-1.  Add two **using** blocks for the **Microsoft.Azure.Storage** and the **Microsoft.Azure.Storage.Blob** namespaces.
+1.  Add two **using** directives for the **Microsoft.Azure.Storage** and the **Microsoft.Azure.Storage.Blob** namespaces.
 
 1.  Delete all the existing code within the **Run** method.
 

--- a/Instructions/Labs/AZ-203_04_lab_ak.md
+++ b/Instructions/Labs/AZ-203_04_lab_ak.md
@@ -613,13 +613,13 @@ In this exercise, you securely used a service identity to read the value of a se
 
 1. Within the editor, delete the existing code within the **Run** method of the script.
 
-1. At the top of the code file, add the following line of code to create a **using** block for the **Microsoft.Azure.Storage** namespace:
+1. At the top of the code file, add the following line of code to create a **using** directive for the **Microsoft.Azure.Storage** namespace:
 
     ```
     using Microsoft.Azure.Storage;
     ```
 
-1. Add the following line of code to create a **using** block for the **Microsoft.Azure.Storage.Blob** namespace:
+1. Add the following line of code to create a **using** directive for the **Microsoft.Azure.Storage.Blob** namespace:
 
     ```
     using Microsoft.Azure.Storage.Blob;

--- a/Instructions/Labs/AZ-203_05_lab.md
+++ b/Instructions/Labs/AZ-203_05_lab.md
@@ -358,7 +358,7 @@ In this exercise, you created an API by using ASP.NET Core and configured it to 
 
 1.  Use the **Explorer** in **Visual Studio Code** to open the **Program.cs** file in the editor.
 
-1.  Add **using** blocks to the top of the file for the following namespaces:
+1.  Add **using** directives to the top of the file for the following namespaces:
     
       - **System.Net.Http**
     

--- a/Instructions/Labs/AZ-203_05_lab_ak.md
+++ b/Instructions/Labs/AZ-203_05_lab_ak.md
@@ -447,13 +447,13 @@ In this exercise, you created an API by using ASP.NET Core and configured it to 
 
 1.  On the left side of the **Visual Studio Code** window, in the **Explorer** pane, double-click the **Program.cs** file to open the file in the editor.
 
-1.  In the editor, add the following **using** block for the **System.Net.Http** namespace:
+1.  In the editor, add the following **using** directive for the **System.Net.Http** namespace:
 
     ```
     using System.Net.Http;
     ```
 
-1.  In the editor, add the following **using** block for the **System.Threading.Tasks** namespace:
+1.  In the editor, add the following **using** directive for the **System.Threading.Tasks** namespace:
 
     ```
     using System.Threading.Tasks;


### PR DESCRIPTION
The course used the phrase **using blocks** inaccurately to refer to [using statements](https://docs.microsoft.com/dotnet/csharp/language-reference/keywords/using-statement) and [using directives](https://docs.microsoft.com/dotnet/csharp/language-reference/keywords/using-directive).

This update corrects the errant usage.