### PR TITLE
Correct "Blobs" to "Containers"

### DIFF
--- a/Instructions/Labs/AZ-203_02_lab.md
+++ b/Instructions/Labs/AZ-203_02_lab.md
@@ -111,7 +111,7 @@ Observe the taskbar located at the bottom of your **Windows 10** desktop. The ta
 
 1.  Access the **imgstor\*** storage account that you created earlier in this lab.
 
-1.  In the **Blob service** section, select the **Blobs** link.
+1.  In the **Blob service** section, select the **Containers** link.
 
 1.  Create a new **container** with the following settings:
     
@@ -538,9 +538,9 @@ In this exercise, you created an Azure Web App and deployed an existing web appl
 
 1.  In the **ManagedPlatform** blade, select the **imgstor\*** storage account that you created earlier in this lab.
 
-1.  In the **Storage Account** blade, in the **Blob service** section on the left side of the blade, select the **Blobs** link.
+1.  In the **Storage Account** blade, in the **Blob service** section on the left side of the blade, select the **Containers** link.
 
-1.  In the **Blobs** section, select the **images** container.
+1.  In the **Containers** section, select the **images** container.
 
 1.  In the **Container** blade, select **Upload**.
 
@@ -558,7 +558,7 @@ In this exercise, you created an Azure Web App and deployed an existing web appl
 
 1.  Close the **Container** blade.
 
-1. Back in the **Blobs** section, select the **images-thumbnails** container.
+1. Back in the **Containers** section, select the **images-thumbnails** container.
 
 1. In the **Container** blade, observe the newly created **veggie.jpg** file in the **images-thumbnails** container.
 


### PR DESCRIPTION
## Location

- Course: AZ-203.2
- Exercise: 1; 3
- Task: 3; 4
- Step[s]: 2; 4, 5, 10

# Proposed Changes
About three weeks ago, the Azure Portal changed the phrasing in the Storage Account UI from "Blobs" to "Containers" - this PR I believe catches all cases of this in this version of the lab.  This should be validated with another set of eyes on the lab.  I'll submit a PR for the AK version as well.

See also #81 
