### PR TITLE
No products available while creating the API

### DIFF
--- a/Instructions/Labs/AZ-203_06_lab_ak.md
+++ b/Instructions/Labs/AZ-203_06_lab_ak.md
@@ -614,8 +614,6 @@ In this exercise, you created an Azure Storage account and indexed a Storage tab
 
 1.  In the **API URL suffix** field, enter **search**.
 
-1.  In the **Products** field, select both **Starter** and **Unlimited**.
-
 1.  Select **Create.**
 
 1.  Wait for the new API to finish being created.


### PR DESCRIPTION
Erasing this step to select Products as part of the definition of the new API in APIM, there are no previous created products. So this step is not relevant and causes confusion to students:

1.  In the **Products** field, select both **Starter** and **Unlimited**.

## Location

- Course: 00
- Exercise: 00
- Task: 00
- Step[s]: 00

# Proposed Changes

-
-
-