### PR TITLE
added ordered list marker

### DIFF
--- a/Instructions/Labs/AZ-203_06_lab.md
+++ b/Instructions/Labs/AZ-203_06_lab.md
@@ -369,7 +369,7 @@ In this exercise, you created an Azure Storage account and indexed a Storage tab
     </outbound>
     ```
 
-And then replacing that block of XML with the following XML:
+1.  And then replacing that block of XML with the following XML:
 
     ```xml
     <outbound>


### PR DESCRIPTION
A missing ordered list marker was messing up code syntax highlight and also numbering of subsequent items

## Location

- Course: AZ203
- Exercise: 3
- Task: 2
- Step[s]: 4,5

# Proposed Changes

-
-
-